### PR TITLE
FLUSH FORCE before ExitProcess call

### DIFF
--- a/foxconsole.prg
+++ b/foxconsole.prg
@@ -182,6 +182,7 @@ define class console as custom
 	endfunc
 
 	function exit(tnReturnValue)
+		FLUSH FORCE
 		=ExitProcess(tnReturnValue)
 	endfunc
 


### PR DESCRIPTION
Prevents open tables from being damaged